### PR TITLE
Adjust keybindings to be more similar to other major modes

### DIFF
--- a/modelica-mode.el
+++ b/modelica-mode.el
@@ -104,6 +104,12 @@
   :options (list 'hs-minor-mode)
   :group 'modelica)
 
+(defcustom modelica-use-emacs-keybindings t
+  "Choose whether to use emacs standard or original keybindings.
+If true, use keybindings similar to other programming modes.  If
+false, use original modelica-mode keybindings; those override
+some standard Emacs keybindings.")
+
 ;;; constants
 
 (defconst mdc-class-modifier-keyword
@@ -244,7 +250,7 @@
   (modify-syntax-entry ?*  ". 23"   mdc-mode-syntax-table)
   (modify-syntax-entry ?\n "> b"    mdc-mode-syntax-table))
 
-(defvar modelica-mode-map
+(defvar modelica-original-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map "\C-j"     'mdc-newline-and-indent)
     (define-key map "\C-c\C-e" 'mdc-insert-end)
@@ -263,6 +269,35 @@
     (define-key map "\ea"      'mdc-to-block-begin)
     (define-key map "\ee"      'mdc-to-block-end)
     map)
+  "Original keymap for `modelica-mode'.
+This keymap overrides some standard Emacs keybindings.")
+
+(defvar modelica-new-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-j")     'mdc-newline-and-indent)
+    (define-key map (kbd "C-c C-e") 'mdc-insert-end)
+    (define-key map (kbd "C-c C-s") 'mdc-show-annotation)
+    (define-key map (kbd "C-c C-h") 'mdc-hide-annotation)
+    (define-key map (kbd "C-c M-s") 'mdc-show-all-annotations)
+    (define-key map (kbd "C-c M-h") 'mdc-hide-all-annotations)
+    (define-key map (kbd "C-c C-c") 'comment-region)
+    (define-key map (kbd "M-\"")    'mdc-indent-for-docstring)
+    (define-key map (kbd "M-;")     'mdc-indent-for-comment)
+    (define-key map (kbd "M-j")     'mdc-indent-new-comment-line)
+    (define-key map (kbd "M-a")     'mdc-backward-statement)
+    (define-key map (kbd "M-e")     'mdc-forward-statement)
+    (define-key map (kbd "M-n")     'mdc-forward-block)
+    (define-key map (kbd "M-p")     'mdc-backward-block)
+    (define-key map (kbd "C-M-a")   'mdc-to-block-begin)
+    (define-key map (kbd "C-M-e")   'mdc-to-block-end)
+    map)
+  "New-style keymap for `modelica-mode'.
+This keymap tries to adhere to Emacs keybindings conventions.")
+
+(defvar modelica-mode-map
+  (if modelica-use-emacs-keybindings
+      modelica-new-mode-map
+    modelica-original-mode-map)
   "Keymap for `modelica-mode'.")
 
 (defvar mdc-mode-menu
@@ -331,6 +366,13 @@
   :group 'modelica
   :syntax-table mdc-mode-syntax-table
   :abbrev-table mdc-mode-abbrev-table
+  ;; Allow switching between original and new keybindings just by setting
+  ;; `modelica-use-emacs-keybindings' and reverting a modelica buffer
+  (setq modelica-mode-map
+        (if modelica-use-emacs-keybindings
+            modelica-new-mode-map
+          modelica-original-mode-map))
+  (use-local-map modelica-mode-map)
   (setq-local indent-line-function 'mdc-indent-line)
   ;; comment syntax
   (setq-local comment-column 32

--- a/modelica-mode.el
+++ b/modelica-mode.el
@@ -34,30 +34,26 @@
 ;;  - show / hide of annotations
 ;;      C-c C-s  show annotation of current statement
 ;;      C-c C-h  hide annotation of current statement
-;;      M-s      show all annotations
-;;      M-h      hide all annotations
+;;      C-c M-s  show all annotations
+;;      C-c M-h  hide all annotations
 ;;
 ;;  - indentation of lines, e.g.
 ;;      TAB      indent current line
-;;      M-x C-\  indent current region
+;;      C-M-\    indent current region
 ;;      C-j      indent current line, create a new line, indent it
 ;;               (like TAB ENTER TAB)
-;;
-;;  - hide/show of annotations
-;;      C-h      hide annotations
-;;      C-s      show annotations
 ;;
 ;;  - automatic insertion of end statements
 ;;      C-c C-e  search backwards for the last unended begin of a code block,
 ;;               insert the according end-statement
 ;;
 ;;  - move commands which know about statements and statement blocks
-;;      M-f      move to next beginning of a statement
-;;      M-b      move to previous beginning of a statement
+;;      M-e      move to next beginning of a statement
+;;      M-a      move to previous beginning of a statement
 ;;      M-n      move to next beginning of a statement block
 ;;      M-p      move to previous beginning of a statement block
-;;      M-a      move to beginning of current statement block
-;;      M-e      move to end of current statement block
+;;      C-M-a    move to beginning of current statement block
+;;      C-M-e    move to end of current statement block
 ;;
 ;;  - commands for writing comments treat documentation strings as well
 ;;      M-;      insert a comment for current statement (standard Emacs)
@@ -337,15 +333,6 @@ This keymap tries to adhere to Emacs keybindings conventions.")
     )
   "Menu for Modelica mode.")
 
-;; define Modelica menu if easymenu is available
-(if (condition-case nil
-	(require 'easymenu)
-      (error nil))
-    (easy-menu-define mdc-mode-menu-symbol
-                      modelica-mode-map
-		      "Menu for Modelica mode"
-		      mdc-mode-menu))
-
 (when (featurep 'hideshow)
   (unless (assoc 'modelica-mode hs-special-modes-alist) ;; one could also use `cl-pushnew'
       (push
@@ -391,9 +378,15 @@ This keymap tries to adhere to Emacs keybindings conventions.")
     ;; XEmacs 21.1 does not know function add-to-invisibility-spec
     (setq-local buffer-invisibility-spec '((mdc-annotation . t))))
   (mdc-hide-all-annotations)
-  ;; add menu
-  (if mdc-mode-menu-symbol
-      (easy-menu-add mdc-mode-menu-symbol)))
+  ;; add menu if easymenu is available
+  (when (condition-case nil
+	    (require 'easymenu)
+          (error nil))
+    (easy-menu-define mdc-mode-menu-symbol
+      modelica-mode-map
+      "Menu for Modelica mode"
+      mdc-mode-menu)
+    (easy-menu-add mdc-mode-menu-symbol modelica-mode-map)))
 
 (defun mdc-indent-for-comment ()
   "Indent this line's comment to comment-column,

--- a/modelica-mode.el
+++ b/modelica-mode.el
@@ -94,14 +94,14 @@
 ;;    see ChangeLog
 
 ;;; customization
+(defgroup modelica nil
+  "Major mode for editing Modelica code."
+  :group 'languages)
 
-(defcustom modelica-mode-hook
-  (append
-   (and (require 'hideshow nil t) (list #'hs-minor-mode))
-   ;; Supported and suggested minor modes can be added here.
-   )
-  "Functions without arguments to be run at start of `modelica-mode'."
+(defcustom modelica-mode-hook nil
+  "Hook run after entering `modelica-mode'."
   :type 'hook
+  :options (list 'hs-minor-mode)
   :group 'modelica)
 
 ;;; constants
@@ -244,28 +244,26 @@
   (modify-syntax-entry ?*  ". 23"   mdc-mode-syntax-table)
   (modify-syntax-entry ?\n "> b"    mdc-mode-syntax-table))
 
-(defvar mdc-mode-map nil
-  "Keymap for Modelica mode.")
-
-(if mdc-mode-map
-    ()
-  (setq mdc-mode-map (make-sparse-keymap))
-  (define-key mdc-mode-map "\C-j"  	'mdc-newline-and-indent)
-  (define-key mdc-mode-map "\C-c\C-e" 	'mdc-insert-end)
-  (define-key mdc-mode-map "\C-c\C-s" 	'mdc-show-annotation)
-  (define-key mdc-mode-map "\C-c\C-h" 	'mdc-hide-annotation)
-  (define-key mdc-mode-map "\es" 	'mdc-show-all-annotations)
-  (define-key mdc-mode-map "\eh" 	'mdc-hide-all-annotations)
-  (define-key mdc-mode-map "\C-c\C-c" 	'comment-region)
-  (define-key mdc-mode-map "\e\""       'mdc-indent-for-docstring)
-  (define-key mdc-mode-map "\e;"        'mdc-indent-for-comment)
-  (define-key mdc-mode-map "\ej"        'mdc-indent-new-comment-line)
-  (define-key mdc-mode-map "\ef"        'mdc-forward-statement)
-  (define-key mdc-mode-map "\eb"        'mdc-backward-statement)
-  (define-key mdc-mode-map "\en"        'mdc-forward-block)
-  (define-key mdc-mode-map "\ep"        'mdc-backward-block)
-  (define-key mdc-mode-map "\ea"        'mdc-to-block-begin)
-  (define-key mdc-mode-map "\ee"        'mdc-to-block-end))
+(defvar modelica-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map "\C-j"     'mdc-newline-and-indent)
+    (define-key map "\C-c\C-e" 'mdc-insert-end)
+    (define-key map "\C-c\C-s" 'mdc-show-annotation)
+    (define-key map "\C-c\C-h" 'mdc-hide-annotation)
+    (define-key map "\es"      'mdc-show-all-annotations)
+    (define-key map "\eh"      'mdc-hide-all-annotations)
+    (define-key map "\C-c\C-c" 'comment-region)
+    (define-key map "\e\""     'mdc-indent-for-docstring)
+    (define-key map "\e;"      'mdc-indent-for-comment)
+    (define-key map "\ej"      'mdc-indent-new-comment-line)
+    (define-key map "\ef"      'mdc-forward-statement)
+    (define-key map "\eb"      'mdc-backward-statement)
+    (define-key map "\en"      'mdc-forward-block)
+    (define-key map "\ep"      'mdc-backward-block)
+    (define-key map "\ea"      'mdc-to-block-begin)
+    (define-key map "\ee"      'mdc-to-block-end)
+    map)
+  "Keymap for `modelica-mode'.")
 
 (defvar mdc-mode-menu
   '("Modelica"
@@ -309,7 +307,7 @@
 	(require 'easymenu)
       (error nil))
     (easy-menu-define mdc-mode-menu-symbol
-		      mdc-mode-map
+                      modelica-mode-map
 		      "Menu for Modelica mode"
 		      mdc-mode-menu))
 
@@ -328,55 +326,32 @@
        hs-special-modes-alist)))
 
 ;;;###autoload
-(defun modelica-mode ()
+(define-derived-mode modelica-mode prog-mode "Modelica"
   "Major mode for editing Modelica files."
-  (interactive)
-  (kill-all-local-variables)
-
-  (setq major-mode 'modelica-mode)
-  (setq mode-name "Modelica")
-
-  (use-local-map mdc-mode-map)
-  (set-syntax-table mdc-mode-syntax-table)
-  (setq local-abbrev-table mdc-mode-abbrev-table)
-
-  (make-local-variable 'indent-line-function)
-  (setq indent-line-function 'mdc-indent-line)
-
+  :group 'modelica
+  :syntax-table mdc-mode-syntax-table
+  :abbrev-table mdc-mode-abbrev-table
+  (setq-local indent-line-function 'mdc-indent-line)
   ;; comment syntax
-  (make-local-variable 'comment-column)
-  (make-local-variable 'comment-start)
-  (make-local-variable 'comment-start-skip)
-  (make-local-variable 'comment-end)
-  (make-local-variable 'comment-multi-line)
-  (setq	comment-column 32
-	comment-start "// "
-	comment-start-skip "/\\*+ *\\|// *"
-	comment-end ""
-	comment-multi-line nil)
-
+  (setq-local comment-column 32
+              comment-start "// "
+              comment-start-skip "/\\*+ *\\|// *"
+              comment-end ""
+              comment-multi-line nil)
   ;; settings for font-lock-mode
-  (make-local-variable 'font-lock-keywords)
-  (setq font-lock-keywords mdc-font-lock-keywords)
+  (setq-local font-lock-keywords mdc-font-lock-keywords)
   ;; font-lock-mode for newer GNU Emacs versions
-  (make-local-variable 'font-lock-defaults)
-  (setq font-lock-defaults '(mdc-font-lock-keywords nil nil))
-
+  (setq-local font-lock-defaults '(mdc-font-lock-keywords nil nil))
   ;; hide/show annotations
-  (make-local-variable 'line-move-ignore-invisible)
-  (setq line-move-ignore-invisible t)
+  (setq-local line-move-ignore-invisible t)
   (if (functionp 'add-to-invisibility-spec)
       (add-to-invisibility-spec '(mdc-annotation . t))
     ;; XEmacs 21.1 does not know function add-to-invisibility-spec
-    (make-local-variable 'buffer-invisibility-spec)
-    (setq buffer-invisibility-spec '((mdc-annotation . t))))
+    (setq-local buffer-invisibility-spec '((mdc-annotation . t))))
   (mdc-hide-all-annotations)
-
   ;; add menu
   (if mdc-mode-menu-symbol
-      (easy-menu-add mdc-mode-menu-symbol))
-
-  (run-hooks 'modelica-mode-hook))
+      (easy-menu-add mdc-mode-menu-symbol)))
 
 (defun mdc-indent-for-comment ()
   "Indent this line's comment to comment-column,


### PR DESCRIPTION
I frequently stumble over Modelica-mode's keybindings, most often `M-f` and `M-b`, but also `C-s`.  This pull request adjusts the keybindings to be similar to other Emacs modes, e.g., cc-mode.

Setting the variable `modelica-use-emacs-keybindings` to NIL reactivates the original keybindings (open buffers must be reverted for the change to take effect).

The first patch uses `define-derived-mode` to define `modelica-mode`, so now we inherit from `prog-mode`, insert the customization group as a submenu of the `languages` customization group, and describe our keybindings in the output of `C-h m` (`describe-mode`).
