### PR TITLE
Avoid false detection of comments within strings

### DIFF
--- a/modelica-mode.el
+++ b/modelica-mode.el
@@ -572,27 +572,12 @@ Assumes point to be over the first non-blank of the line."
   "Return comment starter if point is within a comment, nil otherwise.
 Optionally move point to the beginning of the comment if
 MOVE-POINT is true."
-  (let ((starter nil) (save-point (point)))
-    ;; check single-line comment
-    (setq starter (modelica-within-single-line-comment move-point))
-    (if (not starter)
-	;; check multi-line comment
-	(condition-case nil
-	    (if (and (re-search-backward "/\\*\\|\\*/")
-		     (looking-at "/\\*"))
-		;; check if we arrived in a single-line comment
-		(if (progn (forward-char)
-			   (modelica-within-single-line-comment move-point))
-		    ;; then the original starting point is not a comment
-		    ()
-		  ;; else accept multi-line comment
-		  (backward-char)
-		  (setq starter "/*")))
-	  (error nil)))
-    (if (and starter move-point)
-	(setq save-point (point)))
-    (goto-char save-point)
-    starter))
+  (when-let* ((syn (syntax-ppss))
+	      ((nth 4 syn))
+	      (start (nth 8 syn)))
+    (when move-point
+      (goto-char start))
+    (buffer-substring-no-properties start (+ start 2))))
 
 (defun modelica-within-single-line-comment (&optional move-point)
   "Return comment starter if point is within a single-line comment.


### PR DESCRIPTION
If point is behind the // in the following model the previous version of `(modelica-within-comment)` wrongly returns "//".

```modelica
model withinCommentTest

" // This is a string, it is not a comment! ";

end withinCommentTest;
```