### PR TITLE
Fix #11: Give quotes string syntax.

### DIFF
--- a/modelica-mode.el
+++ b/modelica-mode.el
@@ -249,7 +249,8 @@ some standard Emacs keybindings."
   (modify-syntax-entry ?/  ". 124b" modelica-mode-syntax-table)
 
   (modify-syntax-entry ?*  ". 23"   modelica-mode-syntax-table)
-  (modify-syntax-entry ?\n "> b"    modelica-mode-syntax-table))
+  (modify-syntax-entry ?\n "> b"    modelica-mode-syntax-table)
+  (modify-syntax-entry ?\' "\""    modelica-mode-syntax-table))
 
 (defvar modelica-original-mode-map
   (let ((map (make-sparse-keymap)))


### PR DESCRIPTION
Quoted identifiers [(see section _2.3.1 Identifiers_ of the Modelica specification 3.6)](https://modelica.org/documents/MLS.pdf#page=12) are rarely used. But they can break fontification and syntactic helper functions when they are not taken into account by  `modelica-mode`.

Example:
```
model QuotedIdentifiers
  parameter Integer 'This is a valid " quoted identifier'=10;
end QuotedIdentifiers;
```
Everything after the double-quote is wrongly interpreted as string by `modelica-mode` but the double-quote is actually part of the quoted identifier.

I propose to give quote characters string syntax as a first quick solution. In that case quoted identifiers are fontified as strings and do not break the fontification of the consecutive Modelica source code.